### PR TITLE
fix: Check for knative instead of istio for domain

### DIFF
--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -470,3 +470,16 @@ func (c *Cluster) HasIstio() bool {
 	}
 	return true
 }
+
+// HasKnative checks if Knative serving is installed on the cluster
+func (c *Cluster) HasKnative() bool {
+	_, err := c.Kubectl.CoreV1().Services("knative-serving").Get(
+		context.Background(),
+		"controller",
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -171,7 +171,7 @@ func (c *InstallClient) showInstallConfiguration(opts *kubernetes.InstallationOp
 
 func (c *InstallClient) fillInMissingSystemDomain(domain *kubernetes.InstallationOption) error {
 	if domain.Value.(string) == "" {
-		if c.kubeClient.HasIstio() {
+		if c.kubeClient.HasKnative() {
 			var err error
 			domain.Value, err = c.fetchKnativeDomain()
 			if err != nil {

--- a/scripts/knative-install.sh
+++ b/scripts/knative-install.sh
@@ -11,7 +11,7 @@ export KNATIVE_VERSION=v0.21.0
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
 kubectl apply --filename https://github.com/knative/net-istio/releases/download/${KNATIVE_VERSION}/release.yaml
-kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-default-domain.yaml
+curl -L https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-default-domain.yaml | sed 's/xip.io/omg.howdoi.website/g' | kubectl apply -f -
 
 # Set the knative default revision timeout from 5 minutes to 1 minute as this
 # value is used as temrinationGracePeriod on the pod and it is making deleting


### PR DESCRIPTION
Instead of checking for istio, check if Knative is installed to get the
system domain as knative is what provides the system domain when it is installed.