### PR TITLE
ci: Adapt Carrier release pipeline for FuseML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,12 @@ name: Release-pipeline
 on:
   push:
     tags:
-      - '*'
-        
+      - "v*"
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Changelog
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pullRequests: "false"
-          onlyLastTag: "true"
-          stripGeneratorNotice: "true"
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
@@ -38,11 +30,21 @@ jobs:
       - name: Create CHECKSUMS
         if: steps.branch.outputs.BRANCH_NAME == 'main'
         run: ( cd dist ; sha256sum -b fuseml* > SHA256SUM.txt )
+      - name: Generate Changelog
+        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pullRequests: "false"
+          onlyLastTag: "true"
+          stripGeneratorNotice: "true"
+          issuesWoLabels: "true"
+          stripHeaders: "true"
       - name: Release FuseML
         uses: softprops/action-gh-release@v1
         if: steps.branch.outputs.BRANCH_NAME == 'main'
         with:
           files: ./dist/*
-          body: ${{steps.changelog.outputs.changelog}}
+          body_path: ./CHANGELOG.md
+          prerelease: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TEKTON_DASHBOARD_VERSION=v0.15.0
 
 build: embed_files lint build-local
 
-build-all: embed_files lint build-amd64 build-arm64 build-arm32 build-windows build-darwin
+build-all: embed_files lint build-amd64 build-arm64 build-arm32 build-darwin-amd64 build-darwin-arm64 build-windows
 
 build-all-small:
 	@$(MAKE) LDFLAGS+="-s -w" build-all
@@ -25,14 +25,14 @@ build-arm64: lint
 build-amd64: lint
 	GOARCH="amd64" GOOS="linux" go build -race -ldflags '$(LDFLAGS)' -o dist/fuseml-linux-amd64
 
-build-windows: lint
-	GOARCH="amd64" GOOS="windows" go build -ldflags '$(LDFLAGS)' -o dist/fuseml-windows-amd64
-
-build-darwin: lint
+build-darwin-amd64: lint
 	GOARCH="amd64" GOOS="darwin" go build -ldflags '$(LDFLAGS)' -o dist/fuseml-darwin-amd64
 
 build-darwin-arm64: lint
 	GOARCH="arm64" GOOS="darwin" go build -ldflags '$(LDFLAGS)' -o dist/fuseml-darwin-arm64
+
+build-windows: lint
+	GOARCH="amd64" GOOS="windows" go build -ldflags '$(LDFLAGS)' -o dist/fuseml-windows-amd64
 
 compress:
 	upx --brute -1 ./dist/fuseml-linux-arm32


### PR DESCRIPTION
The pipeline builds the binaries, generates checksums and logs,
and attach them to a pre-release.

The pipeline is automatically triggered by creating a tag starting
with `v`.