### PR TITLE
Fix frozen CI for docs only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,20 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - docs/**
-      - README.md
-      - LICENSE
-      - .gitlint
-      - .gitignore
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - docs/**
-      - README.md
-      - LICENSE
-      - .gitlint
-      - .gitignore
 
 jobs:
   lint:


### PR DESCRIPTION
Without this patch, a doc only change would not trigger the
tests which are required to merge.

This leaves the CI hanging, as in PR #60.

This should fix it by ensuring the necessary tests always run.
