### PR TITLE
Fixes for core service deployment

### DIFF
--- a/deployments/core.go
+++ b/deployments/core.go
@@ -210,7 +210,7 @@ func (core *Core) createCoreDeployment(giteaURL string) error {
 	}
 	defer os.Remove(tmpFilePath)
 
-	out, err := helpers.Kubectl(fmt.Sprintf("apply -n %s --filename %s", coreDeploymentNamespace, tmpFilePath))
+	out, err := helpers.Kubectl(fmt.Sprintf("apply --filename %s", tmpFilePath))
 
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("kubectl apply failed:\n%s", out))

--- a/deployments/core.go
+++ b/deployments/core.go
@@ -188,7 +188,7 @@ func (core Core) createCoreCredsSecret(c *kubernetes.Cluster) error {
 }
 
 // Create fuseml-core deployment pointing to provided gitea server URL
-func (core *Core) createCoreDeployment(giteaURL string) error {
+func (core *Core) createCoreDeployment(giteaURL, tektonURL string) error {
 
 	yamlPathOnDisk, err := helpers.ExtractFile(coreDeploymentYamlPath)
 	if err != nil {
@@ -203,6 +203,9 @@ func (core *Core) createCoreDeployment(giteaURL string) error {
 
 	re := regexp.MustCompile(`__GITEA_URL__`)
 	renderedFileContents := re.ReplaceAllString(string(fileContents), giteaURL)
+
+	re = regexp.MustCompile(`__TEKTON_DASHBOARD_URL__`)
+	renderedFileContents = re.ReplaceAllString(string(renderedFileContents), tektonURL)
 
 	tmpFilePath, err := helpers.CreateTmpFile(string(renderedFileContents))
 	if err != nil {
@@ -251,7 +254,11 @@ func (core Core) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Inst
 	if !exists {
 		giteaURL = "http://gitea." + domain
 	}
-	if err := core.createCoreDeployment(giteaURL); err != nil {
+	tektonURL, exists := os.LookupEnv("TEKTON_DASHBOARD_URL")
+	if !exists {
+		tektonURL = "http://tekton." + domain
+	}
+	if err := core.createCoreDeployment(giteaURL, tektonURL); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Installing %s failed", coreDeploymentYamlPath))
 	}
 

--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -81,6 +81,8 @@ spec:
                 name: fuseml-core-gitea
           - name: GITEA_URL
             value: __GITEA_URL__
+          - name: TEKTON_DASHBOARD_URL
+            value: __TEKTON_DASHBOARD_URL__
         ports:
         - containerPort: 80
 ---        

--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -112,9 +112,9 @@ func (c *InstallClient) Install(cmd *cobra.Command, options *kubernetes.Installa
 		&deployments.Workloads{Timeout: DefaultTimeoutSec},
 		&deployments.MLflow{Timeout: DefaultTimeoutSec},
 		&deployments.Gitea{Timeout: DefaultTimeoutSec},
-		&deployments.Core{Timeout: DefaultTimeoutSec},
 		&deployments.Registry{Timeout: DefaultTimeoutSec},
 		&deployments.Tekton{Timeout: DefaultTimeoutSec},
+		&deployments.Core{Timeout: DefaultTimeoutSec},
 	} {
 		details.Info("deploy", "Deployment", deployment.ID())
 


### PR DESCRIPTION
- Do not pass explicit namespace when creating deployment 
- Pass TEKTON_DASHBOARD_URL value to fuseml-core service 