### PR TITLE
Give the admin rights to fuseml-core ServiceAccount

### DIFF
--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -2,50 +2,24 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: fuseml-core-tekton
+  name: fuseml-core
   namespace: fuseml-core
 ---
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: fuseml-core-tekton
-  namespace: fuseml-workloads
-rules:
-- apiGroups:
-  - tekton.dev
-  resources:
-  - pipelines
-  - pipelineruns
-  verbs:
-  - create
-  - get
-  - list
-  - delete
-- apiGroups:
-  - triggers.tekton.dev
-  resources:
-  - eventlisteners
-  - triggerbindings
-  - triggertemplates
-  verbs:
-  - get
-  - list
-  - create
-  - delete
----
+# Give the admin rights to ServiceAccount, so it can
+# delete various resources forming FuseML applications
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: fuseml-core-tekton-binding
+  name: fuseml-core-admin-binding
   namespace: fuseml-workloads
 subjects:
   - kind: ServiceAccount
-    name: fuseml-core-tekton
+    name: fuseml-core
     namespace: fuseml-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: fuseml-core-tekton
+  kind: ClusterRole
+  name: cluster-admin
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -64,7 +38,7 @@ spec:
       labels:
         app.kubernetes.io/name: fuseml-core
     spec:
-      serviceAccountName: fuseml-core-tekton
+      serviceAccountName: fuseml-core
       containers:
       - name: fuseml-core
         image: ghcr.io/fuseml/fuseml-core:latest


### PR DESCRIPTION
This is fuseml-core can delete various resources forming FuseML
applications (secrets, serviceaccounts, inferenceservices etc.)

Closes #107

Do you think it is too powerful? I've made this after I saw the same is done for tekton: https://github.com/fuseml/fuseml/blob/main/embedded-files/tekton/install/admin-role.yaml#L87

According to this
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles

I think the admin privilegies are tied to the namespace (and not the whole cluster which would be rather scary) when defined this way (see  `kind: RoleBinding`)

_Allows super-user access to perform any action on any resource. When used in a ClusterRoleBinding, it gives full control over every resource in the cluster and in all namespaces. When used in a RoleBinding, it gives full control over every resource in the role binding's namespace, including the namespace itself._