### PR TITLE
fix: rename GITEA_USERNAME, GITEA_PASSWORD to GITEA_ADMIN_*

### DIFF
--- a/deployments/core.go
+++ b/deployments/core.go
@@ -153,21 +153,21 @@ func (core *Core) fetchGiteaCredSecret(c *kubernetes.Cluster) error {
 
 // Create secret to store gitea credentials required by fuseml-core deployment
 // It is possible for user to provide access to different gitea instance than the one deployed by fuseml-installer,
-// however if GITEA_USERNAME, GITEA_PASSWORD, GITEA_URL variables are not set, internal gitea will be used
+// however if GITEA_ADMIN_USERNAME, GITEA_ADMIN_PASSWORD, GITEA_URL variables are not set, internal gitea will be used
 func (core Core) createCoreCredsSecret(c *kubernetes.Cluster) error {
 
-	giteaUsername, exists := os.LookupEnv("GITEA_USERNAME")
+	giteaUsername, exists := os.LookupEnv("GITEA_ADMIN_USERNAME")
 	if !exists {
 		if err := core.fetchGiteaCredSecret(c); err != nil {
-			return errors.Wrap(err, "value for gitea user name (GITEA_USERNAME) was not provided neither found in installed gitea instance")
+			return errors.Wrap(err, "value for gitea admin user name (GITEA_ADMIN_USERNAME) was not provided neither found in installed gitea instance")
 		}
 		giteaUsername = string(core.giteaCredSecret.Data["username"])
 	}
 
-	giteaPassword, exists := os.LookupEnv("GITEA_PASSWORD")
+	giteaPassword, exists := os.LookupEnv("GITEA_ADMIN_PASSWORD")
 	if !exists {
 		if err := core.fetchGiteaCredSecret(c); err != nil {
-			return errors.Wrap(err, "value for gitea user password (GITEA_PASSWORD) was not provided neither found in installed gitea instance")
+			return errors.Wrap(err, "value for gitea admin user password (GITEA_ADMIN_PASSWORD) was not provided neither found in installed gitea instance")
 		}
 		giteaPassword = string(core.giteaCredSecret.Data["password"])
 	}
@@ -178,8 +178,8 @@ func (core Core) createCoreCredsSecret(c *kubernetes.Cluster) error {
 				Name: coreSecretName,
 			},
 			StringData: map[string]string{
-				"GITEA_USERNAME": giteaUsername,
-				"GITEA_PASSWORD": giteaPassword,
+				"GITEA_ADMIN_USERNAME": giteaUsername,
+				"GITEA_ADMIN_PASSWORD": giteaPassword,
 			},
 			Type: "Opaque",
 		}, metav1.CreateOptions{})

--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -69,15 +69,15 @@ spec:
       - name: fuseml-core
         image: ghcr.io/fuseml/fuseml-core:latest
         env:
-          - name: GITEA_USERNAME
+          - name: GITEA_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:
-                key: GITEA_USERNAME
+                key: GITEA_ADMIN_USERNAME
                 name: fuseml-core-gitea
-          - name: GITEA_PASSWORD
+          - name: GITEA_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
-                key: GITEA_PASSWORD
+                key: GITEA_ADMIN_PASSWORD
                 name: fuseml-core-gitea
           - name: GITEA_URL
             value: __GITEA_URL__


### PR DESCRIPTION
This makes it clearer which user/password are the values about

It goes together with https://github.com/fuseml/fuseml-core/pull/61