### PR TITLE
fix: In development branch, fetch "dev" version of fuseml-core image

### DIFF
--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: fuseml-core-tekton
       containers:
       - name: fuseml-core
-        image: ghcr.io/fuseml/fuseml-core:latest
+        image: ghcr.io/fuseml/fuseml-core:dev
         env:
           - name: GITEA_USERNAME
             valueFrom:


### PR DESCRIPTION
fuseml-core is updated automatically with 'dev' tag after every change,
see https://github.com/fuseml/fuseml-core/pull/57