### PR TITLE
fix: Download and unzip fuseml-core client for Windows

### DIFF
--- a/helpers/downloader.go
+++ b/helpers/downloader.go
@@ -2,9 +2,12 @@ package helpers
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
+
+	"github.com/pkg/errors"
 )
 
 // DownloadFile downloads the given url as a file with "name" under "directory"
@@ -36,4 +39,30 @@ func DownloadAndUntar(url, targetDir string) error {
 	defer resp.Body.Close()
 
 	return UntarStream(resp.Body, targetDir)
+}
+
+// DownloadAndUnzip downloads the archive from given url and decopresses it under the target directory
+func DownloadAndUnzip(url, targetDir string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	tmpDir, err := ioutil.TempDir("", "fuseml-core")
+	if err != nil {
+		return errors.Wrap(err, "can't create temp directory for download")
+	}
+	defer os.Remove(tmpDir)
+
+	tmpPath := path.Join(tmpDir, "archive.zip")
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+
+	return Unzip(tmpPath, targetDir)
 }

--- a/helpers/unzip.go
+++ b/helpers/unzip.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Unzip will decompress a zip archive, moving all files and folders
+// within the zip file (parameter 1) to an output directory (parameter 2).
+func Unzip(src string, dest string) error {
+
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// iterate ofer the files in the archive
+	for _, f := range r.File {
+
+		fpath := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip. https://snyk.io/research/zip-slip-vulnerability#go
+		if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("%s: illegal file path", fpath)
+		}
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(fpath, os.ModePerm)
+			continue
+		}
+
+		if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+			return err
+		}
+
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(outFile, rc)
+
+		outFile.Close()
+		rc.Close()
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/paas/install_cli.go
+++ b/paas/install_cli.go
@@ -23,14 +23,24 @@ func downloadFuseMLCLI(ui *ui.UI) error {
 
 	coreClientPlatform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 	name := fmt.Sprintf("%s-%s", coreClientName, coreClientPlatform)
-	url := fmt.Sprintf("%s/%s.tar.gz", coreClientDownloadURL, name)
+	extension := "tar.gz"
+	if runtime.GOOS == "windows" {
+		extension = "zip"
+	}
+
+	url := fmt.Sprintf("%s/%s.%s", coreClientDownloadURL, name, extension)
 	dir, err := os.Getwd()
 	if err != nil {
 		return errors.New("Failed geting current directory")
 	}
 	path := filepath.Join(dir, coreClientName)
 
-	if err := helpers.DownloadAndUntar(url, dir); err != nil {
+	if runtime.GOOS == "windows" {
+		err = helpers.DownloadAndUnzip(url, dir)
+	} else {
+		err = helpers.DownloadAndUntar(url, dir)
+	}
+	if err != nil {
 		return errors.New(fmt.Sprintf("Failed downloading client from %s: %s", url, err.Error()))
 	}
 


### PR DESCRIPTION
Unlike other systems, archive for windows is just zip.