### PR TITLE
Add version information to installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,37 @@ TEKTON_DASHBOARD_VERSION=v0.15.0
 GOOS:=$(shell go env GOOS)
 GOARCH:=$(shell go env GOARCH)
 
+LDFLAGS:= -w -s
+
+PKG_PATH=github.com/fuseml/fuseml/cli/paas
+
+GIT_COMMIT = $(shell git rev-parse --short=8 HEAD)
+GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD|grep -v HEAD)
+GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+ifdef VERSION
+	BINARY_VERSION = $(VERSION)
+else
+# Use `dev` as a default version value when compiling in the main branch
+ifeq ($(GIT_BRANCH),main)
+	BINARY_VERSION = dev
+# Use the branch name as a default version value when compiling in another branch
+else
+	BINARY_VERSION = $(GIT_BRANCH)
+endif
+ifneq ($(GIT_TAG),)
+	BINARY_VERSION = $(GIT_TAG)
+else
+endif
+endif
+
+LDFLAGS += -X $(PKG_PATH)/version.GitCommit=$(GIT_COMMIT)
+LDFLAGS += -X $(PKG_PATH)/version.BuildDate=$(BUILD_DATE)
+ifneq ($(BINARY_VERSION),)
+LDFLAGS += -X $(PKG_PATH)/version.Version=$(BINARY_VERSION)
+endif
+
 ########################################################################
 ## Development
 

--- a/cmd/internal/client/version.go
+++ b/cmd/internal/client/version.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"github.com/fuseml/fuseml/cli/paas"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var ()
+
+// CmdVersion implements the fuseml version command
+var CmdVersion = &cobra.Command{
+	Use:   "version",
+	Short: "Shows version information about the installer",
+	Long:  `Shows the version, git commit, build time and other release information about the installer.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, cleanup, err := paas.NewFusemlClient(cmd.Flags(), nil)
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.Version()
+		if err != nil {
+			return errors.Wrap(err, "error retrieving Fuseml environment information")
+		}
+
+		return nil
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,13 +9,10 @@ import (
 	"github.com/fuseml/fuseml/cli/cmd/internal/client"
 	"github.com/fuseml/fuseml/cli/kubernetes/config"
 	pconfig "github.com/fuseml/fuseml/cli/paas/config"
+	"github.com/fuseml/fuseml/cli/paas/version"
 	"github.com/kyokomi/emoji"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-)
-
-const (
-	Version = "0.1"
 )
 
 var (
@@ -32,7 +29,7 @@ func Execute() {
 		Use:           "fuseml-installer",
 		Short:         "FuseML installer",
 		Long:          `fuseml-installer cli is the official installation tool for FuseML `,
-		Version:       fmt.Sprintf("%s", Version),
+		Version:       version.Version,
 		SilenceErrors: true,
 	}
 
@@ -57,6 +54,7 @@ func Execute() {
 	rootCmd.AddCommand(client.CmdInstall)
 	rootCmd.AddCommand(client.CmdUninstall)
 	rootCmd.AddCommand(client.CmdInfo)
+	rootCmd.AddCommand(client.CmdVersion)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/paas/client.go
+++ b/paas/client.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fuseml/fuseml/cli/kubernetes"
 	"github.com/fuseml/fuseml/cli/paas/config"
 	"github.com/fuseml/fuseml/cli/paas/ui"
+	"github.com/fuseml/fuseml/cli/paas/version"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 )
@@ -33,6 +34,26 @@ func (c *FusemlClient) Info() error {
 		WithStringValue("Platform", platform.String()).
 		WithStringValue("Kubernetes Version", kubeVersion).
 		Msg("Fuseml Environment")
+
+	return nil
+}
+
+// Version displays version information about the installer
+func (c *FusemlClient) Version() error {
+	log := c.Log.WithName("version")
+	log.Info("start")
+	defer log.Info("return")
+
+	version := version.GetInfo()
+
+	c.ui.Success().
+		WithStringValue("Version", version.Version).
+		WithStringValue("GitCommit", version.GitCommit).
+		WithStringValue("Build Date", version.BuildDate).
+		WithStringValue("Go Version", version.GoVersion).
+		WithStringValue("Compiler", version.Compiler).
+		WithStringValue("Platform", version.Platform).
+		Msg("Fuseml Installer")
 
 	return nil
 }

--- a/paas/version/version.go
+++ b/paas/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// Version is the installer version
+	Version string = "unknown"
+
+	// GitCommit is the git commit ID
+	GitCommit string = "unknown"
+
+	// BuildDate is the date when the binary was built
+	BuildDate string = "unknown"
+)
+
+// Info contains versioning information.
+type Info struct {
+	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+	Compiler  string `json:"compiler"`
+	Platform  string `json:"platform"`
+}
+
+// GetInfo returns versioning information.
+func GetInfo() *Info {
+	return &Info{
+		Version:   Version,
+		GitCommit: GitCommit,
+		BuildDate: BuildDate,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
* version information is injected at build time
* add `fuseml-installer version` command to print information about
the installer version

```
> ./fuseml-installer version

  Fuseml Installer
Version: v0.1
GitCommit: 8cd9dc17
Build Date: 2021-06-02T16:32:41Z
Go Version: go1.16
Compiler: gc
Platform: linux/amd64
```