### PR TITLE
fix: Use stable fuseml-core-0.1 for fuseml-installer v0.1

### DIFF
--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: fuseml-core
       containers:
       - name: fuseml-core
-        image: ghcr.io/fuseml/fuseml-core:dev
+        image: ghcr.io/fuseml/fuseml-core:v0.1.0
         imagePullPolicy: Always
         env:
           - name: GITEA_ADMIN_USERNAME

--- a/paas/install_cli.go
+++ b/paas/install_cli.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	coreClientDownloadURL = "https://github.com/fuseml/fuseml-core/releases/latest/download"
+        coreClientDownloadURL = "https://github.com/fuseml/fuseml-core/releases/download/v0.1.0"
 	coreClientName        = "fuseml"
 )
 


### PR DESCRIPTION
This applies for both

- fuseml-core docker image
- fuseml-core client