### PR TITLE
ci: Replace acceptance-tests with mlflow-e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16'
+
       - name: Cache Go modules
         uses: actions/cache@v2
         with:
@@ -36,6 +38,7 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go
+
       - name: Lint
         run: |
           make lint
@@ -46,10 +49,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16'
+
       - name: Cache Go modules
         uses: actions/cache@v2
         with:
@@ -57,19 +62,17 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
+
       - name: Setup Ginkgo Test Framework
         run: |
           go get -u github.com/onsi/ginkgo/ginkgo
+
       - name: Run unit tests
         run: |
           make test
 
-  acceptance-tests:
+  mlflow-e2e:
     runs-on: ubuntu-latest
-    strategy:
-      matrix: 
-        serve: ["traefik", "knative", "kfserving", "seldon_mlflow", "seldon_sklearn"]
-      fail-fast: false
 
     steps:
       - name: Free disk space
@@ -83,12 +86,18 @@ jobs:
           echo
           echo "Available storage:"
           df -h
-      - name: Checkout
+
+      - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16'
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
       - name: Cache Go modules
         uses: actions/cache@v2
         with:
@@ -96,21 +105,24 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
-      - name: Setup Ginkgo Test Framework
+
+      - name: Build fuseml-installer
+        run: make build
+
+      - name: Install k3d
+        run: make k3d-install
+
+      - name: Create k8s cluster
+        run: make new-test-cluster
+
+      - name: Install FuseML
         run: |
-          go get -u github.com/onsi/ginkgo/ginkgo
-      - name: Cache Tools
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
-      - name: Install Tools
+          ./dist/fuseml-installer version
+          make fuseml-install
+
+      - name: Install KFServing
+        run: make kfserving-install
+
+      - name: Run mlflow-e2e
         run: |
-          make tools-install
-          echo "`pwd`/output/bin" >> $GITHUB_PATH
-      - name: Run acceptance tests
-        env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          make test-acceptance-${{ matrix.serve }}
+          make mlflow-e2e

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,24 @@ kfserving-install: knative-install cert-manager-install
 seldon-install:
 	@./scripts/seldon-operator-install.sh
 
+k3d-install:
+	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+
+new-test-cluster:
+	@./scripts/ci/k3d-cluster.sh create
+
+delete-test-cluster:
+	@./scripts/ci/k3d-cluster.sh delete
+
+mlflow-e2e:
+	@./scripts/ci/mlflow-e2e.sh
+
+fuseml-install:
+	@./dist/fuseml-installer install
+
+test-mlflow-e2e: build new-test-cluster fuseml-install kfserving-install mlflow-e2e delete-test-cluster
+
+
 ########################################################################
 # Kube dev environments
 

--- a/scripts/ci/k3d-cluster.sh
+++ b/scripts/ci/k3d-cluster.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# CLUSTER_NAME is fuse-( branch, or tag, fallback to ref )
+CLUSTER_SUFIX=$(echo $(git symbolic-ref -q --short HEAD 2>/dev/null || git describe --tags --exact-match --short HEAD 2>/dev/null || git describe --all | tr '/' -) | tr _ - )
+CLUSTER_NAME=fuseml-${CLUSTER_SUFIX}
+
+if [ "$1" == "create" ]; then
+    k3d_args="--k3s-server-arg --no-deploy=traefik --agents 1"
+fi
+
+
+# Create cluster
+k3d cluster $1 ${k3d_args} ${CLUSTER_NAME}

--- a/scripts/ci/mlflow-e2e.sh
+++ b/scripts/ci/mlflow-e2e.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+print_bold() {
+    echo
+    echo -e "\033[1m$1\033[0m"
+}
+
+if ! git describe --tags --exact-match &> /dev/null; then
+    print_bold "➤ Build FuseML client:"
+    if [ -d "fuseml-core" ]; then
+        cd fuseml-core
+        git fetch origin
+        git reset --hard origin/main
+        git clean -f -d
+    else
+        git clone https://github.com/fuseml/fuseml-core.git
+        cd fuseml-core
+    fi
+    make deps generate build_client
+    mv bin/fuseml ../fuseml
+    cd ..
+    rm -rf fuseml-core
+fi
+
+
+export FUSEML_SERVER_URL=http://$(kubectl get VirtualService -n fuseml-core fuseml-core -o jsonpath="{.spec.hosts[0]}")
+print_bold "⛓  FuseML URL: ${FUSEML_SERVER_URL}"
+./fuseml version
+
+print_bold "➤ Checkout examples repository:"
+if [ -d "fuseml-examples" ]; then
+    cd fuseml-examples
+    git fetch origin
+    git reset --hard origin/main
+    git clean -f -d
+    cd ..
+else
+    git clone --depth 1 https://github.com/fuseml/examples.git fuseml-examples
+fi
+
+print_bold "➤ Register Codeset:"
+./fuseml codeset register --name "mlflow-wines" --project "mlflow-project-01" "fuseml-examples/codesets/mlflow-wines"
+
+export ACCESS=$(kubectl get secret -n fuseml-workloads mlflow-minio -o json | jq -r '.["data"]["accesskey"]' | base64 -d)
+export SECRET=$(kubectl get secret -n fuseml-workloads mlflow-minio -o json | jq -r '.["data"]["secretkey"]' | base64 -d)
+
+sed -i -e "/AWS_ACCESS_KEY_ID/{N;s/value: [^ \t]*/value: $ACCESS/}" fuseml-examples/workflows/mlflow-sklearn-e2e.yaml
+sed -i -e "/AWS_SECRET_ACCESS_KEY/{N;s/value: [^ \t]*/value: $SECRET/}" fuseml-examples/workflows/mlflow-sklearn-e2e.yaml
+
+print_bold "➤ Create Workflow:"
+# Delete workflow if already exists
+if ./fuseml workflow get -n mlflow-sklearn-e2e &> /dev/null; then
+    ./fuseml workflow delete -n mlflow-sklearn-e2e
+fi
+
+./fuseml workflow create fuseml-examples/workflows/mlflow-sklearn-e2e.yaml
+
+print_bold "➤ Assign Workflow:"
+./fuseml workflow assign --name mlflow-sklearn-e2e --codeset-name mlflow-wines --codeset-project mlflow-project-01
+./fuseml workflow list-runs --name mlflow-sklearn-e2e
+
+retries=61
+print_bold "⏱  Waiting $(((retries-1)*15/60))m for the workflow run to finish..."
+run_name=$(./fuseml workflow list-runs --name mlflow-sklearn-e2e --format json | jq -r ".[0].name")
+for i in $(seq ${retries}); do
+    if [[ "${i}" == ${retries} ]]; then
+        print_bold "❌  Timeout waiting for the workflow run to finish."
+        kubectl get pipelineruns ${run_name} -n fuseml-workloads -o json | jq ".status"
+        exit 1
+    fi
+
+    run_status=$(./fuseml workflow list-runs --name mlflow-sklearn-e2e --format json | jq -r ".[0].status")
+    echo "  status: ${run_status} (${i}/$((retries-1)))"
+
+    case ${run_status} in
+        Unknown|Started|Running) sleep 15 ;;
+        Failed)
+            print_bold "❌  Workflow run failed: "
+            kubectl get pipelineruns ${run_name} -n fuseml-workloads -o json | jq ".status"
+            exit 1
+            ;;
+        *) break ;;
+    esac
+done
+
+print_bold "➤ List Applications:"
+./fuseml application list
+
+PREDICTION_URL=$(./fuseml application get -n mlflow-project-01-mlflow-wines --format json | jq -r ".url")
+print_bold "⛓  Prediction URL: ${PREDICTION_URL}"
+
+print_bold "➤ Perform prediction:"
+data="fuseml-examples/prediction/data-wines-kfserving.json"
+curl -sd @${data} ${PREDICTION_URL} | jq
+
+result=$(curl -sd @${data} $PREDICTION_URL | jq -r ".outputs[0].data[0]")
+
+pred_expected_result="6.486344809506676"
+if [[ "$result" != "${pred_expected_result}" ]]; then
+    print_bold "❌  Prediction result expected ${pred_expected_result} but got ${result}"
+    exit 1
+fi

--- a/scripts/knative-install.sh
+++ b/scripts/knative-install.sh
@@ -12,6 +12,8 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/${
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
 kubectl apply --filename https://github.com/knative/net-istio/releases/download/${KNATIVE_VERSION}/release.yaml
 
+kubectl wait --for=condition=available --timeout=600s deployment/controller -n knative-serving
+
 # Set the knative default revision timeout from 5 minutes to 1 minute as this
 # value is used as temrinationGracePeriod on the pod and it is making deleting
 # knative services take at least 5 minutes.
@@ -26,8 +28,6 @@ metadata:
 data:
   revision-timeout-seconds: "60"
 EOF
-
-kubectl wait --for=condition=available --timeout=600s deployment/controller -n knative-serving
 
 # Patch the KNative domain configuration with the domain pointing to the Istio ingress gateway.
 # This is computed as follows:


### PR DESCRIPTION
The mlflow-e2e job performs the following steps:
1. Build fuseml-installer
2. Create a k8s cluster (k3d)
3. Install KFServing
4. Install FuseML
5. Run the steps described on [1]

As this job also covers FuseML installation, replace it.

1. https://github.com/fuseml/fuseml-core#example