### PR TITLE
fix: Set domain for KNative in installation script

### DIFF
--- a/scripts/knative-install.sh
+++ b/scripts/knative-install.sh
@@ -28,3 +28,21 @@ data:
 EOF
 
 kubectl wait --for=condition=available --timeout=600s deployment/controller -n knative-serving
+
+# Patch the KNative domain configuration with the domain pointing to the Istio ingress gateway.
+# This is computed as follows:
+# * if a custom domain was used to install FuseML and FuseML is also using Istio, use that domain
+# * otherwise, compute the domain as an .omg.howdoi.website subdomain from the Istio ingress gateway load balancer IP address
+ISTIO_DOMAIN=$(kubectl get virtualservice fuseml-core -n fuseml-core -o=jsonpath='{.spec.hosts[0]}' | sed -e "s/fuseml-core\.//")
+ISTIO_LB_IP=$(kubectl -n istio-system get service istio-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+if [ -z "$ISTIO_DOMAIN" ]; then
+  if [ ! -z "$ISTIO_LB_IP" ]; then
+    ISTIO_DOMAIN="$ISTIO_LB_IP.omg.howdoi.website"
+  else
+    echo "WARNING: could not update the KNative domain configuration with a domain matching the Istio ingress gateway !"
+    exit
+  fi
+fi
+
+kubectl -n knative-serving patch configmap config-domain --type merge \
+  -p "{\"data\":{\"$ISTIO_DOMAIN\":\"\"}}"


### PR DESCRIPTION
This allows KFServing and its prerequisites (Istio, KNative) to be
installed after FuseML and without impairing functionality.