### PR TITLE
fix: Do not run istio-install target by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ tools-versions:
 istio-install:
 	@./scripts/istio-minimal-install.sh
 
-knative-install: istio-install
+knative-install:
 	@./scripts/knative-install.sh
 
 cert-manager-install:
@@ -160,7 +160,7 @@ cert-manager-install:
 kfserving-install: knative-install cert-manager-install
 	@./scripts/kfserving-install.sh
 
-seldon-install: istio-install
+seldon-install:
 	@./scripts/seldon-operator-install.sh
 
 ########################################################################

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -83,6 +83,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		))
 	}
 
+	fmt.Printf("Installing FuseML on node %d\n", config.GinkgoConfig.ParallelNode)
+	installFuseml()
+
 	if serve == "knative" {
 		fmt.Printf("Installing Knative on node %d\n", config.GinkgoConfig.ParallelNode)
 		installKnative()
@@ -98,8 +101,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		installSeldon()
 	}
 
-	fmt.Printf("Installing FuseML on node %d\n", config.GinkgoConfig.ParallelNode)
-	installFuseml()
 	upgradeFuseml()
 })
 


### PR DESCRIPTION
It is supposed to be installed by fuseml-installer