### PR TITLE
Fixes for CI instability

### DIFF
--- a/cmd/internal/client/install.go
+++ b/cmd/internal/client/install.go
@@ -10,7 +10,7 @@ import (
 var NeededOptions = kubernetes.InstallationOptions{
 	{
 		Name:        "system_domain",
-		Description: "The domain you are planning to use for FuseML. Should be pointing to the traefik public IP (Leave empty to use a omg.howdoi.website domain).",
+		Description: "The domain you are planning to use for FuseML. Should be pointing to the traefik public IP (Leave empty to use a nip.io domain).",
 		Type:        kubernetes.StringType,
 		Default:     "",
 		Value:       "",

--- a/cmd/internal/client/upgrade.go
+++ b/cmd/internal/client/upgrade.go
@@ -10,7 +10,7 @@ import (
 var upgradeOptions = kubernetes.InstallationOptions{
 	{
 		Name:        "system_domain",
-		Description: "The domain you are planning to use for FuseML. Should be pointing to the load balancer public IP (Leave empty to use a omg.howdoi.website domain).",
+		Description: "The domain you are planning to use for FuseML. Should be pointing to the load balancer public IP (Leave empty to use a nip.io domain).",
 		Type:        kubernetes.StringType,
 		Default:     "",
 		Value:       "",

--- a/embedded-files/istio/istio-minimal-operator.yaml
+++ b/embedded-files/istio/istio-minimal-operator.yaml
@@ -7,11 +7,13 @@ spec:
         autoInject: disabled
       useMCP: false
 
-  addonComponents:
-    pilot:
-      enabled: true
-
   components:
+    pilot:
+      k8s:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true

--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -84,7 +84,7 @@ func (c *InstallClient) Install(cmd *cobra.Command, options *kubernetes.Installa
 		return err
 	}
 
-	// Try to give a omg.howdoi.website domain if the user didn't specify one
+	// Try to give a nip.io domain if the user didn't specify one
 	domain, err := options.GetOpt("system_domain", "")
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func (c *InstallClient) Install(cmd *cobra.Command, options *kubernetes.Installa
 		return err
 	}
 	if domain.Value.(string) == "" {
-		return errors.New("You didn't provide a system_domain and we were unable to setup a omg.howdoi.website domain (couldn't find an ExternalIP)")
+		return errors.New("You didn't provide a system_domain and we were unable to setup a nip.io domain (couldn't find an ExternalIP)")
 	}
 	if c.kubeClient.HasKnative() {
 		err = c.setDomainForKnative(domain.Value.(string))
@@ -233,7 +233,7 @@ func (c *InstallClient) fillInMissingSystemDomain(domain *kubernetes.Installatio
 		}
 
 		if ip != "" {
-			domain.Value = fmt.Sprintf("%s.omg.howdoi.website", ip)
+			domain.Value = fmt.Sprintf("%s.nip.io", ip)
 		}
 
 	}

--- a/scripts/istio-minimal-install.sh
+++ b/scripts/istio-minimal-install.sh
@@ -30,11 +30,13 @@ spec:
         autoInject: disabled
       useMCP: false
 
-  addonComponents:
-    pilot:
-      enabled: true
-
   components:
+    pilot:
+      k8s:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true

--- a/scripts/knative-install.sh
+++ b/scripts/knative-install.sh
@@ -12,7 +12,7 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/${
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
 kubectl apply --filename https://github.com/knative/net-istio/releases/download/${KNATIVE_VERSION}/release.yaml
 
-kubectl wait --for=condition=available --timeout=600s deployment/controller -n knative-serving
+kubectl wait --for=condition=available --timeout=600s deployment --all -n knative-serving
 
 # Set the knative default revision timeout from 5 minutes to 1 minute as this
 # value is used as temrinationGracePeriod on the pod and it is making deleting

--- a/scripts/knative-install.sh
+++ b/scripts/knative-install.sh
@@ -32,12 +32,12 @@ EOF
 # Patch the KNative domain configuration with the domain pointing to the Istio ingress gateway.
 # This is computed as follows:
 # * if a custom domain was used to install FuseML and FuseML is also using Istio, use that domain
-# * otherwise, compute the domain as an .omg.howdoi.website subdomain from the Istio ingress gateway load balancer IP address
+# * otherwise, compute the domain as an nip.io subdomain from the Istio ingress gateway load balancer IP address
 ISTIO_DOMAIN=$(kubectl get virtualservice fuseml-core -n fuseml-core -o=jsonpath='{.spec.hosts[0]}' | sed -e "s/fuseml-core\.//")
 ISTIO_LB_IP=$(kubectl -n istio-system get service istio-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
 if [ -z "$ISTIO_DOMAIN" ]; then
   if [ ! -z "$ISTIO_LB_IP" ]; then
-    ISTIO_DOMAIN="$ISTIO_LB_IP.omg.howdoi.website"
+    ISTIO_DOMAIN="$ISTIO_LB_IP.nip.io"
   else
     echo "WARNING: could not update the KNative domain configuration with a domain matching the Istio ingress gateway !"
     exit


### PR DESCRIPTION
This PR includes the following changes with the intent to bring a more stable CI:

- When installing knative wait for all its deployments to be ready before proceeding.
- Lower memory/cpu footprint from Istio
- Switch default domain from "omg.howdoi.website" to "nip.io"