### PR TITLE
fix:Different ways to handle uninstallation of dependencies

### DIFF
--- a/cmd/internal/client/extensions.go
+++ b/cmd/internal/client/extensions.go
@@ -31,6 +31,13 @@ var extensionsOptions = kubernetes.InstallationOptions{
 		Value:       []string{},
 	},
 	{
+		Name:        "with_dependencies",
+		Description: "When removing an extension, remove also all its required extensions",
+		Type:        kubernetes.BooleanType,
+		Default:     false,
+		Value:       true,
+	},
+	{
 		Name:        "list",
 		Description: "List installed FuseML extensions",
 		Type:        kubernetes.BooleanType,

--- a/helpers/strings.go
+++ b/helpers/strings.go
@@ -1,0 +1,11 @@
+package helpers
+
+// simple check if a string is present in a slice
+func StringInSlice(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Until we have good knowledge if a dependent extension really is not
required by something else, simple solution is just uninstall what
was explicitly required by user (see #198)