### PR TITLE
feat: prepare for release v0.2

### DIFF
--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: fuseml-core
       containers:
       - name: fuseml-core
-        image: ghcr.io/fuseml/fuseml-core:dev
+        image: ghcr.io/fuseml/fuseml-core:v0.2
         imagePullPolicy: Always
         env:
           - name: GITEA_ADMIN_USERNAME

--- a/paas/config/config.go
+++ b/paas/config/config.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	defaultConfigFilePath       = os.ExpandEnv("${HOME}/.config/fuseml/config.yaml")
-	defaultExtensionsRepository = "https://raw.githubusercontent.com/fuseml/extensions/main/installer/"
+	defaultExtensionsRepository = "https://raw.githubusercontent.com/fuseml/extensions/release-0.2/installer/"
 )
 
 // Config represents a fuseml config


### PR DESCRIPTION
* update the fuseml-core deployment to use the release fuseml-core
image tag instead of the `dev` tag
* update the default extension repository to point to the `release-*`
extension branch instead of `main`