### PR TITLE
ci: [2.0] Update mlflow e2e CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
     paths-ignore:
       - docs/**
       - README.md
@@ -10,7 +13,9 @@ on:
       - .gitlint
       - .gitignore
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
     paths-ignore:
       - docs/**
       - README.md
@@ -122,4 +127,7 @@ jobs:
 
       - name: Run mlflow-e2e
         run: |
-          make mlflow-e2e
+           # extract the target branch in the context of which this job is running
+           branch=${{ github.base_ref }}
+           [[ -z "$branch" ]] && branch=${GITHUB_REF#refs/heads/}
+           RELEASE_BRANCH=$branch make mlflow-e2e

--- a/.github/workflows/lint_commit_messages.yml
+++ b/.github/workflows/lint_commit_messages.yml
@@ -2,7 +2,9 @@ name: Lint Commit Messages
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
 
 jobs:
   lint:
@@ -16,4 +18,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint new commits
-        run: gitlint --commits "origin/main..HEAD"
+        run: gitlint --commits "origin/${{ github.base_ref }}..HEAD"

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ fuseml-install:
 	@./dist/fuseml-installer install
 
 fuseml-install-with-extensions:
-	@./dist/fuseml-installer install --extensions mlflow,cert-manager,knative,kfserving
+	@./dist/fuseml-installer install --extensions mlflow,kfserving
 
 test-mlflow-e2e: build new-test-cluster fuseml-install-with-extensions mlflow-e2e delete-test-cluster
 


### PR DESCRIPTION
* aligned scripts to the extension registry features
* enabled CI for release branches in github actions
* added a manual CI trigger in github actions
* updated mlflow-e2e CI scripts to make use of consistent
release branches across the board

Backports: #212 