### PR TITLE
ci: [0.2] fix the k3d cluster name

### DIFF
--- a/scripts/ci/k3d-cluster.sh
+++ b/scripts/ci/k3d-cluster.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # CLUSTER_NAME is fuse-( branch, or tag, fallback to ref )
 CLUSTER_SUFIX=$(echo $(git symbolic-ref -q --short HEAD 2>/dev/null || git describe --tags --exact-match --short HEAD 2>/dev/null || git describe --all | tr '/' -) | tr _ - )
-CLUSTER_NAME=fuseml-${CLUSTER_SUFIX}
+CLUSTER_NAME=fuseml-${CLUSTER_SUFIX//[!A-Za-z0-9-]/-}
 
 if [ "$1" == "create" ]; then
     k3d_args="--k3s-server-arg --no-deploy=traefik --agents 1"


### PR DESCRIPTION
When characters other than [A-Za-z0-9-] are used for the branch name,
the CI fails because the generated k3d cluster name only allows those
characters.

Backports: #215 