### PR TITLE
fix: use Recreate update strategy for fuseml-core

### DIFF
--- a/embedded-files/fuseml-core-deployment.yaml
+++ b/embedded-files/fuseml-core-deployment.yaml
@@ -45,6 +45,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: fuseml-core
   replicas: 1
+  strategy:
+    # state is persisted locally and doesn't support shared (i.e. RWX) storage mode
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
The persistent volume used to store badgerdb data can only be
mounted in max one pod at any given time. RollingUpdate upgrade
strategy doesn't work in these circumstances and needs to be
replaced with a Recreate strategy.

Closes https://github.com/fuseml/fuseml/issues/232