### PR TITLE
fix: Update service account for running seldon-core workflows

### DIFF
--- a/deployments/extensions.go
+++ b/deployments/extensions.go
@@ -860,7 +860,7 @@ func (e *Extension) Install(c *kubernetes.Cluster, ui *ui.UI, options *kubernete
 		case "script":
 			err := e.executeScript(step.Location)
 			if err != nil {
-				return errors.Wrap(err, "failed to uninstall using "+step.Location)
+				return errors.Wrap(err, "failed to install using "+step.Location)
 			}
 		default:
 			return errors.New("Unsupported step type: " + step.Type)

--- a/deployments/workloads.go
+++ b/deployments/workloads.go
@@ -34,6 +34,18 @@ var roleRules = []rbacv1.PolicyRule{{
 	APIGroups: []string{"serving.kubeflow.org"},
 	Resources: []string{"inferenceservices"},
 	Verbs:     []string{"get", "list", "create", "patch", "watch"},
+}, {
+	APIGroups: []string{"machinelearning.seldon.io"},
+	Resources: []string{"seldondeployments"},
+	Verbs:     []string{"get", "list", "create", "patch", "watch"},
+}, {
+	APIGroups: []string{"networking.istio.io"},
+	Resources: []string{"gateways"},
+	Verbs:     []string{"get"},
+}, {
+	APIGroups: []string{"apps"},
+	Resources: []string{"deployments"},
+	Verbs:     []string{"get", "list", "watch"},
 }}
 
 func (k *Workloads) ID() string {


### PR DESCRIPTION
Enhance existing `fuseml-workloads` service account so it can read
information necessary for seldon-core based workflows.

Part of https://github.com/fuseml/fuseml/issues/238