### PR TITLE
[0.2] fix: Ensure there is a system domain for upgrade command

### DIFF
--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -335,6 +335,16 @@ func (c *InstallClient) Upgrade(cmd *cobra.Command, options *kubernetes.Installa
 		return err
 	}
 
+	domain, err := options.GetOpt("system_domain", "")
+	if err != nil {
+		return err
+	}
+	details.Info("ensure system-domain")
+	err = c.fillInMissingSystemDomain(domain)
+	if err != nil {
+		return err
+	}
+
 	for _, deployment := range []kubernetes.Deployment{
 		&deployments.Core{Timeout: DefaultTimeoutSec},
 	} {


### PR DESCRIPTION
Upgrade re-creates config map with some env variables,
and the system domain is needed for generating these.

Closes #242.

(cherry picked from commit 589d64a3b1361b3291c442e280e11e950731ddfe)