### PR TITLE
fix: extensions output formatting

### DIFF
--- a/cmd/internal/client/extensions.go
+++ b/cmd/internal/client/extensions.go
@@ -45,7 +45,7 @@ var extensionsOptions = kubernetes.InstallationOptions{
 		Value:       true,
 	},
 	{
-		Name:        "extension_repository",
+		Name:        "extensions_repository",
 		Description: "Path to extensions repository. Could be local directory or URL",
 		Type:        kubernetes.StringType,
 		Default:     config.DefaultExtensionsLocation(),

--- a/cmd/internal/client/install.go
+++ b/cmd/internal/client/install.go
@@ -24,7 +24,7 @@ var InstallOptions = kubernetes.InstallationOptions{
 		Value:       []string{},
 	},
 	{
-		Name:        "extension_repository",
+		Name:        "extensions_repository",
 		Description: "Path to extensions repository. Could be local directory or URL",
 		Type:        kubernetes.StringType,
 		Default:     config.DefaultExtensionsLocation(),

--- a/cmd/internal/client/uninstall.go
+++ b/cmd/internal/client/uninstall.go
@@ -24,7 +24,7 @@ var uninstallOptions = kubernetes.InstallationOptions{
 		Value:       []string{},
 	},
 	{
-		Name:        "extension_repository",
+		Name:        "extensions_repository",
 		Description: "Path to extensions repository. Could be local directory or URL",
 		Type:        kubernetes.StringType,
 		Default:     config.DefaultExtensionsLocation(),

--- a/deployments/extensions.go
+++ b/deployments/extensions.go
@@ -953,7 +953,7 @@ func (e *Extension) Install(c *kubernetes.Cluster, ui *ui.UI, options *kubernete
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("%s failed:\n%s", message, out))
 			}
-			ui.Success().Msg(fmt.Sprintf("%s accessible at http://%s", g.Name, host))
+			ui.Success().KeeplineUnder(1).Msg(fmt.Sprintf("%s accessible at http://%s", g.Name, host))
 		}
 	}
 

--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -171,7 +171,7 @@ func (c *InstallClient) handleExtensions(action string, extensions []string, opt
 		return nil
 	}
 
-	extensionRepo, err := options.GetOpt("extension_repository", "")
+	extensionRepo, err := options.GetOpt("extensions_repository", "")
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func (c *InstallClient) handleExtensions(action string, extensions []string, opt
 
 		switch action {
 		case "install":
-			c.ui.Note().Msg(fmt.Sprintf("Installing extension '%s'...", extension.Name))
+			c.ui.Note().KeeplineUnder(1).Msg(fmt.Sprintf("Installing extension '%s'...", extension.Name))
 			err = extension.Install(c.kubeClient, c.ui, options)
 			if err != nil {
 				return errors.New(fmt.Sprintf("Failed to install extension %s: %s", extension.Name, err.Error()))
@@ -222,13 +222,13 @@ func (c *InstallClient) handleExtensions(action string, extensions []string, opt
 			// uninstall dependencies only when explicitly required on command line or with the command that uninstalls whole fuseml
 			// (https://github.com/fuseml/fuseml/issues/198)
 			if withDeps || helpers.StringInSlice(extensions, extension.Name) {
-				c.ui.Note().Msg(fmt.Sprintf("Unregistering extension '%s'...", extension.Name))
+				c.ui.Note().KeeplineUnder(1).Msg(fmt.Sprintf("Unregistering extension '%s'...", extension.Name))
 				err = extension.UnRegister(c.kubeClient, c.ui, options)
 				if err != nil {
 					return errors.New(fmt.Sprintf("Failed to unregister extension %s: %s", extension.Name, err.Error()))
 				}
 
-				c.ui.Note().Msg(fmt.Sprintf("Removing extension '%s'...", extension.Name))
+				c.ui.Note().KeeplineUnder(1).Msg(fmt.Sprintf("Removing extension '%s'...", extension.Name))
 				err = extension.Uninstall(c.kubeClient, c.ui, options)
 				if err != nil {
 					return errors.New(fmt.Sprintf("Failed to uninstall extension %s: %s", extension.Name, err.Error()))


### PR DESCRIPTION
When installing/uninstalling extensions keep the same output format that
is used when installing FuseML.

Also, fixes references to `extension` where it should be `extensions`.