### PR TITLE
fix: Print the service location only when VirtualService was created

### DIFF
--- a/deployments/extensions.go
+++ b/deployments/extensions.go
@@ -953,7 +953,9 @@ func (e *Extension) Install(c *kubernetes.Cluster, ui *ui.UI, options *kubernete
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("%s failed:\n%s", message, out))
 			}
-			ui.Success().KeeplineUnder(1).Msg(fmt.Sprintf("%s accessible at http://%s", g.Name, host))
+			if g.ServiceHost != "" {
+				ui.Success().KeeplineUnder(1).Msg(fmt.Sprintf("%s accessible at http://%s", g.Name, host))
+			}
 		}
 	}
 


### PR DESCRIPTION
For example for seldon-core, VirtualService is not created and it
does not make sense to show URL with wildcards.