### PR TITLE
feat: add permissions to create OVMS related resources

### DIFF
--- a/deployments/workloads.go
+++ b/deployments/workloads.go
@@ -39,9 +39,17 @@ var roleRules = []rbacv1.PolicyRule{{
 	Resources: []string{"seldondeployments"},
 	Verbs:     []string{"get", "list", "create", "patch", "watch"},
 }, {
+	APIGroups: []string{"intel.com"},
+	Resources: []string{"ovms"},
+	Verbs:     []string{"get", "list", "create", "patch", "watch"},
+}, {
 	APIGroups: []string{"networking.istio.io"},
 	Resources: []string{"gateways"},
 	Verbs:     []string{"get"},
+}, {
+	APIGroups: []string{"networking.istio.io"},
+	Resources: []string{"virtualservices"},
+	Verbs:     []string{"get", "list", "create", "patch", "watch"},
 }, {
 	APIGroups: []string{"apps"},
 	Resources: []string{"deployments"},


### PR DESCRIPTION
Extend the set of permissions associated with the Tekton service
account to enable the OVMS predictor workflow step to create
necessary OVMS kubernetes resources.

Resolve: fuseml/fuseml#257