### PR TITLE
Make it possible to update the workflow role from extension

### DIFF
--- a/deployments/workloads.go
+++ b/deployments/workloads.go
@@ -290,6 +290,37 @@ func (w Workloads) createWorkloadsRole(c *kubernetes.Cluster) error {
 	return err
 }
 
+// Update the role with new rule
+func (w Workloads) updateWorkloadsRole(c *kubernetes.Cluster, newRule rbacv1.PolicyRule) error {
+
+	role, err := c.Kubectl.RbacV1().Roles(WorkloadsDeploymentID).Get(
+		context.Background(),
+		WorkloadsDeploymentID,
+		metav1.GetOptions{},
+	)
+
+	for _, rule := range role.Rules {
+		// this is only a simple check for exact duplicates; we ignore the situation
+		// when e.g. the new rule is subset of existing one
+		if helpers.StringSlicesEqual(rule.APIGroups, newRule.APIGroups) &&
+			helpers.StringSlicesEqual(rule.Resources, newRule.Resources) &&
+			helpers.StringSlicesEqual(rule.Verbs, newRule.Verbs) {
+			return nil
+		}
+	}
+
+	role, err = c.Kubectl.RbacV1().Roles(WorkloadsDeploymentID).Update(
+		context.Background(),
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: WorkloadsDeploymentID,
+			},
+			Rules: append(role.Rules, newRule),
+		}, metav1.UpdateOptions{})
+
+	return err
+}
+
 func (w Workloads) createWorkloadsRoleBinding(c *kubernetes.Cluster) error {
 	_, err := c.Kubectl.RbacV1().RoleBindings(WorkloadsDeploymentID).Create(
 		context.Background(),

--- a/deployments/workloads.go
+++ b/deployments/workloads.go
@@ -31,26 +31,6 @@ var roleRules = []rbacv1.PolicyRule{{
 	Resources: []string{"secrets", "serviceaccounts"},
 	Verbs:     []string{"get", "create", "patch"},
 }, {
-	APIGroups: []string{"serving.kubeflow.org"},
-	Resources: []string{"inferenceservices"},
-	Verbs:     []string{"get", "list", "create", "patch", "watch"},
-}, {
-	APIGroups: []string{"machinelearning.seldon.io"},
-	Resources: []string{"seldondeployments"},
-	Verbs:     []string{"get", "list", "create", "patch", "watch"},
-}, {
-	APIGroups: []string{"intel.com"},
-	Resources: []string{"ovms"},
-	Verbs:     []string{"get", "list", "create", "patch", "watch"},
-}, {
-	APIGroups: []string{"networking.istio.io"},
-	Resources: []string{"gateways"},
-	Verbs:     []string{"get"},
-}, {
-	APIGroups: []string{"networking.istio.io"},
-	Resources: []string{"virtualservices"},
-	Verbs:     []string{"get", "list", "create", "patch", "watch"},
-}, {
 	APIGroups: []string{"apps"},
 	Resources: []string{"deployments"},
 	Verbs:     []string{"get", "list", "watch"},

--- a/helpers/strings.go
+++ b/helpers/strings.go
@@ -1,5 +1,7 @@
 package helpers
 
+import "sort"
+
 // simple check if a string is present in a slice
 func StringInSlice(s []string, str string) bool {
 	for _, v := range s {
@@ -8,4 +10,20 @@ func StringInSlice(s []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// Check if given slices of strings have same content
+// (different order of items counts as same slice)
+func StringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sort.Strings(a)
+	sort.Strings(b)
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
TODO:

- [x] solve at least duplicate rules (there's probably gonna be duplicate `networking.istio.io`/`gateways`/`get` rule for seldon-core and ovms)
- [ ] delete rules on deleting the extension? This could be problematic, as more extensions could use one specific rule (see above point) and it such case we should not delete...
- [x] remove hard coded intel rules (once the ovms extension is merged)

requires https://github.com/fuseml/extensions/pull/44