### PR TITLE
ci: Use latest version of k3d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,8 @@ seldon-install:
 	@./scripts/seldon-operator-install.sh
 
 k3d-install:
-	export TAG=v4.4.7 && curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+	k3d version
 
 new-test-cluster:
 	@./scripts/ci/k3d-cluster.sh create

--- a/scripts/ci/k3d-cluster.sh
+++ b/scripts/ci/k3d-cluster.sh
@@ -4,13 +4,14 @@ set -e
 set -o pipefail
 
 # CLUSTER_NAME is fuse-( branch, or tag, fallback to ref )
-CLUSTER_SUFIX=$(echo $(git symbolic-ref -q --short HEAD 2>/dev/null || git describe --tags --exact-match --short HEAD 2>/dev/null || git describe --all | tr '/' -) | tr _ - )
+CLUSTER_SUFIX=$(git symbolic-ref -q --short HEAD 2>/dev/null || git describe --tags --exact-match --short HEAD 2>/dev/null || git describe --all | tr '/' - | tr _ - )
 CLUSTER_NAME=fuseml-${CLUSTER_SUFIX//[!A-Za-z0-9-]/-}
 
 if [ "$1" == "create" ]; then
-    k3d_args="--k3s-server-arg --no-deploy=traefik --agents 1"
+    k3d_args="--k3s-arg --disable=traefik@server:* --agents 1"
 fi
 
 
 # Create cluster
+echo "k3d cluster $1 ${k3d_args} ${CLUSTER_NAME}"
 k3d cluster $1 ${k3d_args} ${CLUSTER_NAME}


### PR DESCRIPTION
With the release of k3d v5.0 (k3s v1.21.5-k3s1), the previous issue
that was breaking CI is fixed.