### PR TITLE
fix: Make sure to not break 3rd party extensions

### DIFF
--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -429,6 +429,24 @@ func (c *Cluster) NamespaceExistsAndOwned(namespaceName string) (bool, error) {
 	return owned, nil
 }
 
+// NamespaceExistsAndNotOwned returns true only if the namespace exists
+// but was NOT created by fuseml
+func (c *Cluster) NamespaceExistsAndNotOwned(namespaceName string) (bool, error) {
+	exists, err := c.NamespaceExists(namespaceName)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+
+	owned, err := c.NamespaceLabelExists(namespaceName, FusemlDeploymentLabelKey)
+	if err != nil {
+		return false, err
+	}
+	return !owned, nil
+}
+
 // NamespaceExists checks if a namespace exists or not
 func (c *Cluster) NamespaceExists(namespaceName string) (bool, error) {
 	_, err := c.Kubectl.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})


### PR DESCRIPTION
By labeling the namespaces created for extensions,
make sure to

- detect existing extensions and not overwrite them (closes #273)
- only delete the extensions that were installed by fuseml (closes #272)