### PR TITLE
feat: Allow reinstalation of extensions

### DIFF
--- a/cmd/internal/client/extensions.go
+++ b/cmd/internal/client/extensions.go
@@ -38,6 +38,13 @@ var extensionsOptions = kubernetes.InstallationOptions{
 		Value:       true,
 	},
 	{
+		Name:        "force_reinstall",
+		Description: "Reinstall existing extensions (only if they were previously installed by FuseML)",
+		Type:        kubernetes.BooleanType,
+		Default:     false,
+		Value:       true,
+	},
+	{
 		Name:        "list",
 		Description: "List installed FuseML extensions",
 		Type:        kubernetes.BooleanType,

--- a/cmd/internal/client/install.go
+++ b/cmd/internal/client/install.go
@@ -30,6 +30,13 @@ var InstallOptions = kubernetes.InstallationOptions{
 		Default:     config.DefaultExtensionsLocation(),
 		Value:       "",
 	},
+	{
+		Name:        "force_reinstall",
+		Description: "Reinstall existing extensions (only if they were previously installed by FuseML)",
+		Type:        kubernetes.BooleanType,
+		Default:     false,
+		Value:       true,
+	},
 }
 
 const (

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -411,6 +411,14 @@ func (c *Cluster) LabelNamespace(namespace, labelKey, labelValue string) error {
 	return nil
 }
 
+func (c *Cluster) NamespaceOwned(namespaceName string) (bool, error) {
+	owned, err := c.NamespaceLabelExists(namespaceName, FusemlDeploymentLabelKey)
+	if err != nil {
+		return false, err
+	}
+	return owned, err
+}
+
 // NamespaceExistsAndOwned checks if the namespace exists
 // and is created by fuseml or not.
 func (c *Cluster) NamespaceExistsAndOwned(namespaceName string) (bool, error) {
@@ -422,11 +430,7 @@ func (c *Cluster) NamespaceExistsAndOwned(namespaceName string) (bool, error) {
 		return false, nil
 	}
 
-	owned, err := c.NamespaceLabelExists(namespaceName, FusemlDeploymentLabelKey)
-	if err != nil {
-		return false, err
-	}
-	return owned, nil
+	return c.NamespaceOwned(namespaceName)
 }
 
 // NamespaceExistsAndNotOwned returns true only if the namespace exists
@@ -439,12 +443,11 @@ func (c *Cluster) NamespaceExistsAndNotOwned(namespaceName string) (bool, error)
 	if !exists {
 		return false, nil
 	}
-
-	owned, err := c.NamespaceLabelExists(namespaceName, FusemlDeploymentLabelKey)
+	owned, err := c.NamespaceOwned(namespaceName)
 	if err != nil {
 		return false, err
 	}
-	return !owned, nil
+	return !owned, err
 }
 
 // NamespaceExists checks if a namespace exists or not


### PR DESCRIPTION
Until now, reinstalation was the default option for non-helm based
exensions. This PR;

- changes the default behavior: if fuseml finds existing extension,
it will not touch it
- add new command line argument ("--force-reinstall") that allows
user to reinstall extensions that were previously installed by FuseML.

The extensions installed by third party won't be touched in either case.

Closes #205