### PR TITLE
ci: use correct application name in e2e tests

### DIFF
--- a/scripts/ci/mlflow-e2e.sh
+++ b/scripts/ci/mlflow-e2e.sh
@@ -117,7 +117,7 @@ print_bold "➤ List Applications:"
 ./fuseml application list
 
 for cs in ${CODESETS}; do
-    PREDICTION_URL=$(./fuseml application get -n mlflow-${cs} --format json | jq -r ".url")
+    PREDICTION_URL=$(./fuseml application get -n mlflow-${cs}-${WORKFLOW} --format json | jq -r ".url")
     print_bold "⛓  [${cs}] Prediction URL: ${PREDICTION_URL}"
 
     print_bold "➤ Perform prediction:"


### PR DESCRIPTION
The generated application names now include the workflow name.