### PR TITLE
fix: not enough arguments in call `deployments.GetRegisteredExtensions`

### DIFF
--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -301,7 +301,8 @@ func (c *InstallClient) Uninstall(cmd *cobra.Command, options *kubernetes.Instal
 	if len(exts) == 0 && core.Installed(c.kubeClient) {
 		details.Info("removing all registered extensions")
 
-		registeredExts, err := deployments.GetRegisteredExtensions(options)
+		client := deployments.NewHttpClient(c.ui.Verbose())
+		registeredExts, err := deployments.GetRegisteredExtensions(options, client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Client is missing when calling `deployments.GetRegisteredExtensions` resulting
in failure when building.