### PR TITLE
[0.3] ci: Added a path to test Seldon-Core with Triton based workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ["kserve", "seldon", "ovms"]
+        target: ["kserve", "seldon", "seldon-triton", "ovms"]
 
     steps:
       - name: Free disk space

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,9 @@ mlflow-kserve-e2e:
 mlflow-seldon-e2e:
 	@./scripts/ci/mlflow-e2e.sh seldon
 
+mlflow-seldon-triton-e2e:
+	@./scripts/ci/mlflow-e2e.sh seldon triton
+
 mlflow-ovms-e2e:
 	@./scripts/ci/mlflow-e2e.sh ovms
 
@@ -176,6 +179,9 @@ fuseml-install-with-kserve:
 	@./dist/fuseml-installer install --extensions mlflow,kserve
 
 fuseml-install-with-seldon:
+	@./dist/fuseml-installer install --extensions mlflow,seldon-core
+
+fuseml-install-with-seldon-triton:
 	@./dist/fuseml-installer install --extensions mlflow,seldon-core
 
 fuseml-install-with-ovms:


### PR DESCRIPTION
keras codeset + mlflow-seldon-triton-e2e.yaml worklfow

(cherry picked from commit 5356c1cc72891c00fea7d7e47176718ee41ef9e1)

Backport of https://github.com/fuseml/fuseml/pull/293