### PR TITLE
[0.3] ci: don't test the installer twice on release

### DIFF
--- a/.github/workflows/get-fuseml-installer.yml
+++ b/.github/workflows/get-fuseml-installer.yml
@@ -2,9 +2,15 @@ name: Get fuseml-installer script
 on:
   workflow_call:
   pull_request:
+    branches:
+      - main
+      - release-*
     paths:
       - "install.sh"
   push:
+    branches:
+      - main
+      - release-*
     paths:
       - "install.sh"
 jobs:


### PR DESCRIPTION
The fuseml-installer test github action is currently triggered on
every possible push event on every branch: commits, but also tags. 
This has the effect that this test is triggered twice when a release
tag is published: once on the actual tag push event and a second time
as a dependency in the release action tree.

Specifying the list of branches in the action trigger excludes tags
from the list of events that trigger this workflow. It will only be
executed on PR push and when commits are merged.

Backports #304 