### PR TITLE
fix: download core client version appropriate for the installer

### DIFF
--- a/paas/install_cli.go
+++ b/paas/install_cli.go
@@ -1,26 +1,102 @@
 package paas
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/fuseml/fuseml/cli/deployments"
 	"github.com/fuseml/fuseml/cli/helpers"
 	"github.com/fuseml/fuseml/cli/paas/ui"
+	"github.com/fuseml/fuseml/cli/paas/version"
 	"github.com/pkg/errors"
 )
 
 const (
-	coreClientDownloadURL = "https://github.com/fuseml/fuseml-core/releases/latest/download"
+	coreAPIURL            = "https://api.github.com/repos/fuseml/fuseml-core/releases"
+	coreClientDownloadURL = "https://github.com/fuseml/fuseml-core/releases"
 	coreClientName        = "fuseml"
 )
+
+// structure covering tiny part of github release json information
+type Release struct {
+	URL     string `json:"html_url,omitempty"`
+	TagName string `json:"tag_name,omitempty"`
+}
+
+// Find out latest applicable version of the core client for the installer;
+// installer version provided as argument
+func latestClientForInstaller(version string) (string, error) {
+
+	resp, err := http.Get(coreAPIURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, resp.Body)
+
+	releases := []Release{}
+	err = json.Unmarshal(buf.Bytes(), &releases)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse description file")
+	}
+
+	installer := strings.Split(version, ".")
+	major := installer[0]
+	minor := installer[1]
+
+	clientRelease := ""
+
+	// The list of releases is already sorted from the latest one,
+	// so we do not need to check the patch version and just take the first one
+	for _, release := range releases {
+		tag := strings.Split(release.TagName, ".")
+		coreMajor := tag[0]
+		coreMinor := tag[1]
+		if major == coreMajor && minor >= coreMinor {
+			clientRelease = release.TagName
+			break
+		}
+	}
+	return clientRelease, nil
+}
 
 // download platform specific fuseml command line client to current directory
 func downloadFuseMLCLI(ui *ui.UI, domain string) error {
 
 	ui.Note().KeeplineUnder(1).Msg("Downloading command line client...")
+
+	downloadURL := coreClientDownloadURL
+	installerVersion := version.Version
+
+	isRelease, err := regexp.MatchString(`^v[0-9]+\.[0-9]+\.?[0-9]*$`, installerVersion)
+	if err != nil {
+		return errors.Wrap(err, "failed to identify installer version")
+	}
+
+	if isRelease {
+		clientVersion, err := latestClientForInstaller(installerVersion)
+		if err != nil {
+			return errors.Wrap(err, "failed to identify necessary client version")
+		}
+		if clientVersion == "" {
+			return errors.New(fmt.Sprintf("Failed to find correct client version for installer version %s", installerVersion))
+		}
+		ui.Note().Msg(fmt.Sprintf("For installer version %s, downloading client version %s", installerVersion, clientVersion))
+		downloadURL = downloadURL + "/download/" + clientVersion
+	} else {
+		downloadURL += "/latest/download"
+		ui.Note().Msg("Downloading latest stable version of the client")
+	}
 
 	coreClientPlatform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 	name := fmt.Sprintf("%s-%s", coreClientName, coreClientPlatform)
@@ -29,7 +105,7 @@ func downloadFuseMLCLI(ui *ui.UI, domain string) error {
 		extension = "zip"
 	}
 
-	url := fmt.Sprintf("%s/%s.%s", coreClientDownloadURL, name, extension)
+	url := fmt.Sprintf("%s/%s.%s", downloadURL, name, extension)
 	dir, err := os.Getwd()
 	if err != nil {
 		return errors.New("Failed geting current directory")
@@ -45,9 +121,8 @@ func downloadFuseMLCLI(ui *ui.UI, domain string) error {
 		return errors.New(fmt.Sprintf("Failed downloading client from %s: %s", url, err.Error()))
 	}
 
-	ui.Note().Msg(fmt.Sprintf(
-		"FuseML command line client saved as %s.\nCopy it to the location within your PATH (e.g. /usr/local/bin).",
-		path))
+	ui.Success().Msg(fmt.Sprintf("FuseML command line client saved as %s.", path))
+	ui.Normal().Msg("    It is recommended to copy it to the location within your PATH (e.g. /usr/local/bin).")
 
 	fuseml_url := fmt.Sprintf("http://%s.%s", deployments.CoreDeploymentID, domain)
 	ui.Note().Msg(fmt.Sprintf(


### PR DESCRIPTION
When downloading the core client binary, check the installer version
and take the client version that is expected to be compatible, i.e.
it is the latest one that only differs in patch version.

closes #300

I've also changed the UI a little bit, this is how it looks for released version:
```bash
🚢 Downloading command line client...
🚢 For installer version v0.2, downloading client version v0.2.1

✔️  FuseML command line client saved as /home/jsuchome/kubernetes/fuseml/fuseml.

    It is recommended to copy it to the location within your PATH (e.g. /usr/local/bin).
```
and for dev version:
```bash
🚢 Downloading command line client...
🚢 Downloading latest stable version of the client

✔️  FuseML command line client saved as /home/jsuchome/kubernetes/fuseml/fuseml.

    It is recommended to copy it to the location within your PATH (e.g. /usr/local/bin).
```

Better to show the screenshot, to see different colors:

![fuseml-install-cli](https://user-images.githubusercontent.com/910000/144075612-39e81524-4618-4657-9f8f-7386b4491095.png)

